### PR TITLE
Fix query

### DIFF
--- a/lib/pinecone.ex
+++ b/lib/pinecone.ex
@@ -376,6 +376,12 @@ defmodule Pinecone do
     end
   end
 
+  defp post_root(path, name, body, opts) do
+    with {:ok, host} <- index_host(name) do
+      HTTP.post({:root, host}, path, body, opts)
+    end
+  end
+
   defp index_host(index_name) do
     with {:ok, %{"host" => host}} <- describe_index(index_name) do
       {:ok, host}
@@ -434,7 +440,7 @@ defmodule Pinecone do
 
     body = if opts[:namespace], do: Map.put(body, "namespace", opts[:namespace]), else: body
 
-    post_vector("query", name, body, opts[:config])
+    post_root("query", name, body, opts[:config])
   end
 
   ## Collection Operations

--- a/lib/pinecone/http.ex
+++ b/lib/pinecone/http.ex
@@ -70,6 +70,10 @@ defmodule Pinecone.HTTP do
     Path.join("https://#{host}/vectors", endpoint)
   end
 
+  defp url({:root, host}, endpoint, _env) do
+    Path.join("https://#{host}", endpoint)
+  end
+
   defp headers(api_key) do
     api_key =
       if api_key do


### PR DESCRIPTION
It appeared that the URL for [query operation](https://docs.pinecone.io/reference/api/data-plane/query) shouldn't contain `/vectors` path component.   It should be just 
```
POST https://{index_host}/query
```

The below line that was producing an incorrect URL:
```
post_vector("query", name, body, opts[:config])
```